### PR TITLE
Use exclusively Common Crawl's new Public Dataset bucket s3://commoncrawl/

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ locally, which will avoid using too much disk-space
 
 The new index announced at http://blog.commoncrawl.org/2015/04/announcing-the-common-crawl-index/ is supported now
 
-Indexes are available at s3://aws-publicdatasets/common-crawl/cc-index/collections/[CC-MAIN-YYYY-WW], 
-e.g. https://aws-publicdatasets.s3.amazonaws.com/common-crawl/cc-index/collections/CC-MAIN-2015-11/metadata.yaml
+Indexes are available at s3://commoncrawl/cc-index/collections/[CC-MAIN-YYYY-WW], 
+e.g. https://commoncrawl.s3.amazonaws.com/cc-index/collections/CC-MAIN-2015-11/metadata.yaml
 
 Indexing is done via https://github.com/ikreymer/webarchive-indexing
 
@@ -76,7 +76,7 @@ CDX file format is described at https://github.com/ikreymer/webarchive-indexing#
 
 For example, if you have the query result from http://index.commoncrawl.org/CC-MAIN-2015-11-index?url=commoncrawl.org&output=json&limit=1
 
-    {"urlkey": "org,commoncrawl)/", "timestamp": "20150302032705", "url": "http://commoncrawl.org/", "length": "2526", "filename": "common-crawl/crawl-data/CC-MAIN-2015-11/segments/1424936462700.28/warc/CC-MAIN-20150226074102-00159-ip-10-28-5-156.ec2.internal.warc.gz", "digest": "QE4UUUWUJWEZBBK6PUG3CHFAGEKDMDBZ", "offset": "53235662"}
+    {"urlkey": "org,commoncrawl)/", "timestamp": "20150302032705", "url": "http://commoncrawl.org/", "length": "2526", "filename": "crawl-data/CC-MAIN-2015-11/segments/1424936462700.28/warc/CC-MAIN-20150226074102-00159-ip-10-28-5-156.ec2.internal.warc.gz", "digest": "QE4UUUWUJWEZBBK6PUG3CHFAGEKDMDBZ", "offset": "53235662"}
 
 You can access the original resource via this url, using curl or wget:
 
@@ -96,7 +96,7 @@ This replay serves the original response http headers as well, which may not be 
 
 Actually it looks like awscli knows how to output to stdout now too.  Here's a one-liner which will generate a pseudo-random ~1% sample of the first shard in the March 2015 index.  It runs in under 3 minutes on my laptop (using ~25 Mb/s download bandwidth).
 
- time aws s3 cp --no-sign-request s3://aws-publicdatasets/common-crawl/cc-index/collections/CC-MAIN-2015-14/indexes/cdx-00000.gz - | gunzip | cut -f 4 -d '"' | awk 'BEGIN {srand()} !/^$/ { if (rand() <= .01) print $0}' | gzip > cdx-00000-url-1pct.txt.gz
+ time aws s3 cp --no-sign-request s3://commoncrawl/cc-index/collections/CC-MAIN-2015-14/indexes/cdx-00000.gz - | gunzip | cut -f 4 -d '"' | awk 'BEGIN {srand()} !/^$/ { if (rand() <= .01) print $0}' | gzip > cdx-00000-url-1pct.txt.gz
 
 You can adjust this by changing the probability threshold from .01 to something else or by tossing a grep stage into the pipe to filter on URLs matching certain patterns.
 
@@ -134,14 +134,14 @@ which should filter out results that had a content type of text/html only. This 
 
 Those fields are 'offset' and 'length' in the current index, and correspond to the WARC offset and compressed length that you would use as part of the range request.
 
-{"urlkey": "org,commoncrawl)/", "timestamp": "20150302032705", "url": "http://commoncrawl.org/", "length": "2526", "filename": "common-crawl/crawl-data/CC-MAIN-2015-11/segments/1424936462700.28/warc/CC-MAIN-20150226074102-00159-ip-10-28-5-156.ec2.internal.warc.gz", "digest": "QE4UUUWUJWEZBBK6PUG3CHFAGEKDMDBZ", "offset": "53235662"}
+{"urlkey": "org,commoncrawl)/", "timestamp": "20150302032705", "url": "http://commoncrawl.org/", "length": "2526", "filename": "crawl-data/CC-MAIN-2015-11/segments/1424936462700.28/warc/CC-MAIN-20150226074102-00159-ip-10-28-5-156.ec2.internal.warc.gz", "digest": "QE4UUUWUJWEZBBK6PUG3CHFAGEKDMDBZ", "offset": "53235662"}
 
 
 53238187=53235662+2526-1
 
 You could then do:
 
-curl -r 53235662-53238187 https://aws-publicdatasets.s3.amazonaws.com/common-crawl/crawl-data/CC-MAIN-2015-11/segments/1424936462700.28/warc/CC-MAIN-20150226074102-00159-ip-10-28-5-156.ec2.internal.warc.gz | zcat | less
+curl -r 53235662-53238187 https://commoncrawl.s3.amazonaws.com/crawl-data/CC-MAIN-2015-11/segments/1424936462700.28/warc/CC-MAIN-20150226074102-00159-ip-10-28-5-156.ec2.internal.warc.gz | zcat | less
 
 to get the full WARC record.
 

--- a/download.sh
+++ b/download.sh
@@ -3,4 +3,4 @@
 sudo mkdir -p /usbb/commoncrawl && \
 sudo chmod a+w /usbb/commoncrawl && \
 wget -O /usbb/commoncrawl/index.data -v -c --limit-rate=1000k --progress=bar \
-	https://aws-publicdatasets.s3.amazonaws.com/common-crawl/projects/url-index/url-index.1356128792
+	https://commoncrawl.s3.amazonaws.com/projects/url-index/url-index.1356128792

--- a/src/main/java/org/dstadler/commoncrawl/DocumentLocation.java
+++ b/src/main/java/org/dstadler/commoncrawl/DocumentLocation.java
@@ -33,17 +33,9 @@ public class DocumentLocation {
     
     public String getUrl() {
     	if(filename != null) {
-    		//"filename": "common-crawl/crawl-data/CC-MAIN-2015-35/segments/1440645293619.80/warc/CC-MAIN-20150827031453-00044-ip-10-171-96-226.ec2.internal.warc.gz"}		 */
-            // in newer crawls:
-            //"filename": "crawl-data/CC-MAIN-2016-18/segments/1461860111838.20/warc/CC-MAIN-20160428161511-00162-ip-10-239-7-51.ec2.internal.warc.gz"
-            if(filename.replaceAll(".*(CC-MAIN-\\d{4}-\\d{2}).*", "$1").compareTo("CC-MAIN-2016-18") >= 0) {
-                // changed URL for the files
-                return "https://commoncrawl.s3.amazonaws.com/" + filename;
-            } else {
-                return "https://aws-publicdatasets.s3.amazonaws.com/" + filename;
-            }
+            return "https://commoncrawl.s3.amazonaws.com/" + filename;
     	}
-        return "https://aws-publicdatasets.s3.amazonaws.com/common-crawl/parse-output/segment/" + 
+        return "https://commoncrawl.s3.amazonaws.com/parse-output/segment/" + 
                 segmentId + "/" + arcCreationDate + "_" + arcFilePartition + ".arc.gz";
     }
 

--- a/src/main/java/org/dstadler/commoncrawl/Utils.java
+++ b/src/main/java/org/dstadler/commoncrawl/Utils.java
@@ -38,7 +38,7 @@ public class Utils {
     public static final int INDEX_BLOCK_COUNT = 2644;
     public static final int BLOCK_SIZE = 65536;
 
-    public static final String INDEX_URL = "https://aws-publicdatasets.s3.amazonaws.com/common-crawl/projects/url-index/url-index.1356128792";
+    public static final String INDEX_URL = "https://commoncrawl.s3.amazonaws.com/projects/url-index/url-index.1356128792";
     public static final int HEADER_BLOCK_SIZE = 8;
     public static File DOWNLOAD_DIR = new File("../download");
     public static final File COMMONURLS_PATH = new File("commonurls.txt");

--- a/src/main/java/org/dstadler/commoncrawl/index/CDXItem.java
+++ b/src/main/java/org/dstadler/commoncrawl/index/CDXItem.java
@@ -29,7 +29,7 @@ public class CDXItem {
 		/*
 {"url": "http://www.malthus.com.br/rw/forense/o_alcoolismo_e_a_lei.ppt", "mime": "application/vnd.ms-powerpoint", "status": "200",
 "digest": "PRKAHBCWKV2357EMC4H5Q2I56SSL34KB", "length": "474522", "offset": "548823139",
-"filename": "common-crawl/crawl-data/CC-MAIN-2015-35/segments/1440645293619.80/warc/CC-MAIN-20150827031453-00044-ip-10-171-96-226.ec2.internal.warc.gz"}		 */
+"filename": "crawl-data/CC-MAIN-2015-35/segments/1440645293619.80/warc/CC-MAIN-20150827031453-00044-ip-10-171-96-226.ec2.internal.warc.gz"}		 */
 		CDXItem item = new CDXItem();
 
     	try (JsonParser jp = f.createParser(json)) {

--- a/src/test/java/org/dstadler/commoncrawl/DocumentLocationTest.java
+++ b/src/test/java/org/dstadler/commoncrawl/DocumentLocationTest.java
@@ -27,7 +27,7 @@ public class DocumentLocationTest {
 	
 	        DocumentLocation header = DocumentLocation.readFromOldIndexBlock(block, index+1);
 	
-	        assertEquals("https://aws-publicdatasets.s3.amazonaws.com/common-crawl/parse-output/segment/1346876860779/1346958145255_226.arc.gz", 
+	        assertEquals("https://commoncrawl.s3.amazonaws.com/parse-output/segment/1346876860779/1346958145255_226.arc.gz", 
 	                header.getUrl());
 	
 	        assertEquals("bytes=77856771-77862431", header.getRangeHader());
@@ -57,7 +57,7 @@ public class DocumentLocationTest {
 	            count--;
 	            if(count >= 0) {
 	                assertTrue(UrlUtils.isAvailable(
-	                        "https://aws-publicdatasets.s3.amazonaws.com/common-crawl/parse-output/segment/1346876860609/1346967937731_3908.arc.gz", 
+	                        "https://commoncrawl.s3.amazonaws.com/parse-output/segment/1346876860609/1346967937731_3908.arc.gz", 
 	                        false, 10_000));
 	            }
 	

--- a/src/test/java/org/dstadler/commoncrawl/index/DownloadFromCommonCrawlTest.java
+++ b/src/test/java/org/dstadler/commoncrawl/index/DownloadFromCommonCrawlTest.java
@@ -20,8 +20,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 public class DownloadFromCommonCrawlTest {
-	private static final String line = "{\"url\": \"http://www.gjk.gov.al/include_php/previewdoc.php?id_kerkesa_vendimi=1359&nr_vendim=1\", \"mime\": \"application/msword\", \"status\": \"200\", \"digest\": \"FMRMNDSLHYJCIYGOPKBLYQDFE5LJB4SS\", \"length\": \"12298\", \"offset\": \"460161775\", \"filename\": \"common-crawl/crawl-data/CC-MAIN-2015-35/segments/1440645199297.56/warc/CC-MAIN-20150827031319-00038-ip-10-171-96-226.ec2.internal.warc.gz\"}";
-	private static final String line_2015_48 = "{\"url\": \"http://ddp.org.za/programme-events/local-government/conference/2008/Municipal%20Services%20Partnerships%20Local%20Perspective.doc/\", \"mime\": \"application/msword\", \"status\": \"200\", \"digest\": \"QVDVT5WG6SWRQBISUEXRNX6RAEXKX26K\", \"length\": \"32901\", \"offset\": \"62916137\", \"filename\": \"common-crawl/crawl-data/CC-MAIN-2015-48/segments/1448398468971.92/warc/CC-MAIN-20151124205428-00118-ip-10-71-132-137.ec2.internal.warc.gz\"}";
+	private static final String line = "{\"url\": \"http://www.gjk.gov.al/include_php/previewdoc.php?id_kerkesa_vendimi=1359&nr_vendim=1\", \"mime\": \"application/msword\", \"status\": \"200\", \"digest\": \"FMRMNDSLHYJCIYGOPKBLYQDFE5LJB4SS\", \"length\": \"12298\", \"offset\": \"460161775\", \"filename\": \"crawl-data/CC-MAIN-2015-35/segments/1440645199297.56/warc/CC-MAIN-20150827031319-00038-ip-10-171-96-226.ec2.internal.warc.gz\"}";
+	private static final String line_2015_48 = "{\"url\": \"http://ddp.org.za/programme-events/local-government/conference/2008/Municipal%20Services%20Partnerships%20Local%20Perspective.doc/\", \"mime\": \"application/msword\", \"status\": \"200\", \"digest\": \"QVDVT5WG6SWRQBISUEXRNX6RAEXKX26K\", \"length\": \"32901\", \"offset\": \"62916137\", \"filename\": \"crawl-data/CC-MAIN-2015-48/segments/1448398468971.92/warc/CC-MAIN-20151124205428-00118-ip-10-71-132-137.ec2.internal.warc.gz\"}";
 
 	@Ignore("Just for local testing")
 	@Test

--- a/src/test/java/org/dstadler/commoncrawl/index/DownloadURLIndexTest.java
+++ b/src/test/java/org/dstadler/commoncrawl/index/DownloadURLIndexTest.java
@@ -28,7 +28,7 @@ public class DownloadURLIndexTest {
 	public void testRead() throws Exception {
         try (HttpClientWrapper client = new HttpClientWrapper("", null, 30_000)) {
 
-        	String url = "https://aws-publicdatasets.s3.amazonaws.com/common-crawl/cc-index/collections/CC-MAIN-2015-48/indexes/cdx-00000.gz";
+        	String url = "https://commoncrawl.s3.amazonaws.com/cc-index/collections/CC-MAIN-2015-48/indexes/cdx-00000.gz";
         	log.info("Loading data from " + url);
 
         	final HttpGet httpGet = new HttpGet(url);
@@ -95,7 +95,7 @@ public class DownloadURLIndexTest {
 	public void testReadDirectly() throws Exception {
         try (HttpClientWrapper client = new HttpClientWrapper("", null, 30_000)) {
 
-        	String url = "https://aws-publicdatasets.s3.amazonaws.com/common-crawl/cc-index/collections/CC-MAIN-2015-48/indexes/cdx-00000.gz";
+        	String url = "https://commoncrawl.s3.amazonaws.com/cc-index/collections/CC-MAIN-2015-48/indexes/cdx-00000.gz";
         	log.info("Loading data from " + url);
 
         	final HttpGet httpGet = new HttpGet(url);

--- a/src/test/java/org/dstadler/commoncrawl/index/TestDownloadFile.java
+++ b/src/test/java/org/dstadler/commoncrawl/index/TestDownloadFile.java
@@ -29,7 +29,7 @@ import org.dstadler.commoncrawl.Utils;
 @SuppressWarnings("deprecation")
 public class TestDownloadFile {
     private static final String URL =
-    		"https://aws-publicdatasets.s3.amazonaws.com/common-crawl/cc-index/collections/CC-MAIN-2015-48/indexes/cdx-00000.gz";
+    		"https://commoncrawl.s3.amazonaws.com/cc-index/collections/CC-MAIN-2015-48/indexes/cdx-00000.gz";
 
     public static void main(String[] args) throws Exception {
     	HttpClientBuilder builder = HttpClients.custom();


### PR DESCRIPTION
Common Crawl data is going to be removed from the old public dataset bucket (s3://aws-publicdatasets/common-crawl/). All data, also from pre-2016 crawls, is available on the new bucket (s3://commoncrawl/). The index files on the new bucket are consistent, entries point to the right path [[1](https://groups.google.com/forum/m/#!msg/common-crawl/uqtE7Cc6OEU/cIsEcwskEAAJ).